### PR TITLE
Normalize package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/nazka/map-gl-js-spiderfy.git"
+    "url": "git+https://github.com/nazka/map-gl-js-spiderfy.git"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- update `package.json` repository metadata from an SSH GitHub URL to a public `git+https` URL
- leave runtime code, dependencies, package version, and package contents unchanged

## Validation
- metadata assertion for `package.json` repository URL
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`